### PR TITLE
[#156302820] Increase TCP max line length to 99990

### DIFF
--- a/syslog/drainer.go
+++ b/syslog/drainer.go
@@ -37,7 +37,7 @@ func NewDrainer(drain Drain, hostname string) (*drainer, error) {
 			nil,
 			30*time.Second,
 			30*time.Second,
-			9990,
+			99990,
 		)
 
 		if err != nil {


### PR DESCRIPTION
## What

Note: this is a fork of cloudfoundry/blackbox but I rolled back one commit (which just updated the go import paths to cloudfoudry/blackbox) to match concourse/blackbox which is what we need in our case.

We want to be able to send longer log messages than ~10k.

Also this seems like a typo as in the used library the default value is 99990. [1]

[1] https://github.com/papertrail/remote_syslog2/blob/bb588fe75acc16fc38c5d66c9d365aff9c911129/config.go#L82

## How to review

Code review

## Who can review it

Not me.
